### PR TITLE
Tippfehler in ASCIIKunst behoben

### DIFF
--- a/src/main/java/ASCIIKunst.java
+++ b/src/main/java/ASCIIKunst.java
@@ -3,7 +3,7 @@ import java.util.Scanner;
 public class ASCIIKunst {
     public static void main(String[] args) {
         Scanner sc1 = new Scanner(System.in);
-        System.out.print("Wähle zwichen Viereck (1) und Dreieck (2) aus:");
+        System.out.print("Wähle zwischen Viereck (1) und Dreieck (2) aus:");
         int auswahl = sc1.nextInt();
         int a = 0;
         int b = 0;


### PR DESCRIPTION
Im ersten Scanner im Programm "ASCII-Kunst" wurde ein Tippfehler behoben ("zwischen" statt "zwichen")